### PR TITLE
修复因windows换行符，不一样导致，代码着色失败。

### DIFF
--- a/lib/source_code_view.dart
+++ b/lib/source_code_view.dart
@@ -27,6 +27,7 @@ class _SourceCodeViewState extends State<SourceCodeView> {
   double _textScaleFactor = 1.0;
 
   Widget _getCodeView(String codeContent, BuildContext context) {
+    codeContent = codeContent.replaceAll('\r\n', '\n');
     final SyntaxHighlighterStyle style =
         Theme.of(context).brightness == Brightness.dark
             ? SyntaxHighlighterStyle.darkThemeStyle()


### PR DESCRIPTION
修复出先的这个问题。
[1](https://github.com/X-Wei/widget_with_codeview/issues/3)

发现作者是中国人，非常高兴，厉害厉害。
